### PR TITLE
feat: add native auth helper for login

### DIFF
--- a/client/src/lib/nativeAuth.ts
+++ b/client/src/lib/nativeAuth.ts
@@ -1,0 +1,61 @@
+import { Capacitor } from "@capacitor/core";
+import type { PluginListenerHandle } from "@capacitor/core";
+import { App } from "@capacitor/app";
+import { Browser } from "@capacitor/browser";
+
+const LOGIN_PATH = "/api/login";
+const NATIVE_AUTH_DEEP_LINK = "golfai://auth/callback"; // Stub #1 deep link
+
+function buildNativeLoginUrl() {
+  const encodedReturnTo = encodeURIComponent(NATIVE_AUTH_DEEP_LINK);
+  return `${LOGIN_PATH}?returnTo=${encodedReturnTo}`;
+}
+
+type NavigateHome = () => void;
+
+export async function startNativeAuthFlow(
+  navigateHome: NavigateHome
+): Promise<(() => void) | void> {
+  if (!Capacitor.isNativePlatform()) {
+    window.location.href = LOGIN_PATH;
+    return;
+  }
+
+  let listenerHandle: PluginListenerHandle | undefined;
+  const loginUrl = buildNativeLoginUrl();
+
+  try {
+    listenerHandle = await App.addListener("appUrlOpen", async (event) => {
+      const incomingUrl = event.url ?? "";
+
+      if (!incomingUrl.startsWith(NATIVE_AUTH_DEEP_LINK)) {
+        return;
+      }
+
+      navigateHome();
+      await Browser.close();
+
+      if (listenerHandle) {
+        await listenerHandle.remove();
+        listenerHandle = undefined;
+      }
+    });
+
+    await Browser.open({ url: loginUrl });
+
+    return () => {
+      if (!listenerHandle) {
+        return;
+      }
+
+      void listenerHandle.remove();
+      listenerHandle = undefined;
+    };
+  } catch (error) {
+    if (listenerHandle) {
+      void listenerHandle.remove();
+    }
+
+    throw error;
+  }
+}

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -1,9 +1,37 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Play, Target, TrendingUp, Users } from "lucide-react";
+import { startNativeAuthFlow } from "@/lib/nativeAuth";
 
 export default function Landing() {
+  const [, navigate] = useLocation();
+  const cleanupRef = useRef<(() => void) | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (cleanupRef.current) {
+        cleanupRef.current();
+        cleanupRef.current = undefined;
+      }
+    };
+  }, []);
+
+  const handleLogin = useCallback(() => {
+    if (cleanupRef.current) {
+      cleanupRef.current();
+      cleanupRef.current = undefined;
+    }
+
+    startNativeAuthFlow(() => navigate("/")).then((cleanup) => {
+      cleanupRef.current = cleanup ?? undefined;
+    }).catch((error) => {
+      console.error("Failed to initiate login", error);
+    });
+  }, [navigate]);
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 dark:from-green-950 dark:to-blue-950">
       <div className="container mx-auto px-4 py-16">
@@ -20,9 +48,9 @@ export default function Landing() {
             Upload your golf swing videos and get instant, professional-level analysis. 
             Track your progress, manage your clubs, and improve your game with AI-powered insights.
           </p>
-          <Button 
-            onClick={() => window.location.href = "/api/login"}
-            size="lg" 
+          <Button
+            onClick={handleLogin}
+            size="lg"
             className="bg-green-600 hover:bg-green-700 text-white px-8 py-3 text-lg"
           >
             Get Started
@@ -126,9 +154,9 @@ export default function Landing() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <Button 
-                onClick={() => window.location.href = "/api/login"}
-                size="lg" 
+              <Button
+                onClick={handleLogin}
+                size="lg"
                 className="bg-green-600 hover:bg-green-700 text-white"
               >
                 Start Your Free Analysis

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@capacitor/app": "^7.0.2",
+        "@capacitor/browser": "^7.0.2",
         "@capacitor/cli": "^7.4.3",
         "@capacitor/core": "^7.4.3",
         "@capacitor/ios": "^7.4.3",
@@ -423,6 +425,24 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-7.1.0.tgz",
+      "integrity": "sha512-W7m09IWrUjZbo7AKeq+rc/KyucxrJekTBg0l4QCm/yDtCejE3hebxp/W2esU26KKCzMc7H3ClkUw32E9lZkwRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/browser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-7.0.2.tgz",
+      "integrity": "sha512-5kySTunCtH+2sezmTjgDfwvspW7GW/hslQECZeLIRM2qefnxjGTc3fmCTeILYK5EuvcxMs+8sF5BhmzzKqOzuQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@capacitor/cli": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
+    "@capacitor/app": "^7.0.2",
+    "@capacitor/browser": "^7.0.2",
     "@capacitor/cli": "^7.4.3",
     "@capacitor/core": "^7.4.3",
     "@capacitor/ios": "^7.4.3",


### PR DESCRIPTION
## Summary
- add a native authentication helper that builds the deep-link login URL, opens the Capacitor Browser on native devices, and watches for appUrlOpen events to return users home
- update the landing page buttons to use the new helper with proper listener cleanup so native navigation and web redirects share the same entry point
- include the @capacitor/app and @capacitor/browser plugins in the project dependencies

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d59ed92a988328b9eb46e2f8cdae59