### PR TITLE
feat: register golfai URL scheme for native login

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -49,5 +49,16 @@
         <string>SwingAI needs access to your camera to record and analyze your golf swing for personalized feedback and improvement tips.</string>
         <key>NSMicrophoneUsageDescription</key>
         <string>SwingAI needs access to your microphone to record audio with your golf swing videos for complete analysis.</string>
+        <key>CFBundleURLTypes</key>
+        <array>
+                <dict>
+                        <key>CFBundleURLName</key>
+                        <string>com.swingai.golfapp</string>
+                        <key>CFBundleURLSchemes</key>
+                        <array>
+                                <string>golfai</string>
+                        </array>
+                </dict>
+        </array>
 </dict>
 </plist>

--- a/replit.md
+++ b/replit.md
@@ -88,6 +88,7 @@ The application follows a full-stack architecture with a React frontend, Express
 - **Production**: Runs compiled JavaScript bundle
 - **Database**: Requires `DATABASE_URL` environment variable
 - **AI Integration**: Requires `GEMINI_API_KEY` environment variable
+- **Native Auth Callback**: Native apps handle login redirects via the `golfai://auth/callback` deep link scheme registered in Capacitor
 
 ### Key Architectural Decisions
 


### PR DESCRIPTION
## Summary
- register the `golfai` deep link scheme in the iOS Info.plist so native login callbacks reopen the app
- document the native login callback URL used by the Capacitor build configuration

## Testing
- npx cap sync ios

------
https://chatgpt.com/codex/tasks/task_e_68d5a0e59ff88328906f26904dc2655b