### PR TITLE
Add native deep link schemes to iOS app

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -59,6 +59,14 @@
                                 <string>golfai</string>
                         </array>
                 </dict>
+                <dict>
+                        <key>CFBundleURLName</key>
+                        <string>capacitor-localhost</string>
+                        <key>CFBundleURLSchemes</key>
+                        <array>
+                                <string>capacitor</string>
+                        </array>
+                </dict>
         </array>
 </dict>
 </plist>

--- a/replit.md
+++ b/replit.md
@@ -88,7 +88,7 @@ The application follows a full-stack architecture with a React frontend, Express
 - **Production**: Runs compiled JavaScript bundle
 - **Database**: Requires `DATABASE_URL` environment variable
 - **AI Integration**: Requires `GEMINI_API_KEY` environment variable
-- **Native Auth Callback**: Native apps handle login redirects via the `golfai://auth/callback` deep link scheme registered in Capacitor
+- **Native Auth Callback**: Native apps handle login redirects via the `golfai://auth/callback` deep link scheme registered in Capacitor (with a fallback `capacitor://` host for the in-app browser)
 
 ### Key Architectural Decisions
 


### PR DESCRIPTION
## Summary
- add the capacitor:// scheme to Info.plist so iOS recognizes native deep links alongside golfai://
- document the new deep link fallback host in the Replit guide

## Testing
- npx cap sync ios

------
https://chatgpt.com/codex/tasks/task_e_68d5a7736db88328bb609a7cea43c49b