### PR TITLE
Handle native login deep link redirects

### DIFF
--- a/client/src/lib/nativeAuth.ts
+++ b/client/src/lib/nativeAuth.ts
@@ -1,0 +1,81 @@
+import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
+import { App, type URLOpenListenerEvent } from "@capacitor/app";
+import { Browser } from "@capacitor/browser";
+
+import { resolveApiUrl } from "./api";
+
+const NATIVE_RETURN_URL = "golfai://auth";
+let appUrlListener: PluginListenerHandle | undefined;
+
+function resolveReturnPath(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    const explicitPath = parsed.searchParams.get("path");
+    if (explicitPath && explicitPath.startsWith("/")) {
+      return explicitPath;
+    }
+
+    const normalizedPath = parsed.pathname;
+    if (normalizedPath && normalizedPath !== "/") {
+      return normalizedPath.startsWith("/") ? normalizedPath : `/${normalizedPath}`;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function defaultReturnHandler(target?: string) {
+  if (target) {
+    window.location.href = target;
+  } else {
+    window.location.href = "/";
+  }
+}
+
+export async function launchLogin(onReturn?: (target?: string) => void) {
+  if (!Capacitor.isNativePlatform()) {
+    window.location.href = "/api/login";
+    return;
+  }
+
+  await cleanupNativeAuthListener();
+
+  const listener = await App.addListener("appUrlOpen", async (event: URLOpenListenerEvent) => {
+    if (!event.url || !event.url.toLowerCase().startsWith(NATIVE_RETURN_URL)) {
+      return;
+    }
+
+    await Browser.close();
+    await cleanupNativeAuthListener();
+
+    const handler = onReturn ?? defaultReturnHandler;
+    const target = resolveReturnPath(event.url) ?? "/";
+    handler(target);
+  });
+
+  appUrlListener = listener;
+
+  const loginUrl = new URL(resolveApiUrl("/api/login"), window.location.origin);
+  loginUrl.searchParams.set("returnTo", NATIVE_RETURN_URL);
+
+  const loginTarget = loginUrl.toString();
+
+  if (!/^https?:\/\//i.test(loginTarget)) {
+    console.error(
+      "Native login requires VITE_API_BASE_URL to be set to a fully qualified https URL. Falling back to window navigation.",
+    );
+    window.location.href = loginTarget;
+    return;
+  }
+
+  await Browser.open({ url: loginTarget, presentationStyle: "popover" });
+}
+
+export async function cleanupNativeAuthListener() {
+  if (appUrlListener) {
+    await appUrlListener.remove();
+    appUrlListener = undefined;
+  }
+}

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -2,8 +2,24 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Play, Target, TrendingUp, Users } from "lucide-react";
+import { useCallback, useEffect } from "react";
+import { useLocation } from "wouter";
+
+import { cleanupNativeAuthListener, launchLogin } from "@/lib/nativeAuth";
 
 export default function Landing() {
+  const [, setLocation] = useLocation();
+
+  useEffect(() => {
+    return () => {
+      void cleanupNativeAuthListener();
+    };
+  }, []);
+
+  const handleLogin = useCallback(() => {
+    void launchLogin(() => setLocation("/"));
+  }, [setLocation]);
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 dark:from-green-950 dark:to-blue-950">
       <div className="container mx-auto px-4 py-16">
@@ -20,9 +36,9 @@ export default function Landing() {
             Upload your golf swing videos and get instant, professional-level analysis. 
             Track your progress, manage your clubs, and improve your game with AI-powered insights.
           </p>
-          <Button 
-            onClick={() => window.location.href = "/api/login"}
-            size="lg" 
+          <Button
+            onClick={handleLogin}
+            size="lg"
             className="bg-green-600 hover:bg-green-700 text-white px-8 py-3 text-lg"
           >
             Get Started
@@ -126,9 +142,9 @@ export default function Landing() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <Button 
-                onClick={() => window.location.href = "/api/login"}
-                size="lg" 
+              <Button
+                onClick={handleLogin}
+                size="lg"
                 className="bg-green-600 hover:bg-green-700 text-white"
               >
                 Start Your Free Analysis

--- a/ios/App/App.xcworkspace/contents.xcworkspacedata
+++ b/ios/App/App.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:App.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -49,5 +49,18 @@
         <string>SwingAI needs access to your camera to record and analyze your golf swing for personalized feedback and improvement tips.</string>
         <key>NSMicrophoneUsageDescription</key>
         <string>SwingAI needs access to your microphone to record audio with your golf swing videos for complete analysis.</string>
+        <key>CFBundleURLTypes</key>
+        <array>
+                <dict>
+                        <key>CFBundleTypeRole</key>
+                        <string>Editor</string>
+                        <key>CFBundleURLName</key>
+                        <string>golfai</string>
+                        <key>CFBundleURLSchemes</key>
+                        <array>
+                                <string>golfai</string>
+                        </array>
+                </dict>
+        </array>
 </dict>
 </plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@capacitor/app": "^7.1.0",
+        "@capacitor/browser": "^7.0.2",
         "@capacitor/cli": "^7.4.3",
         "@capacitor/core": "^7.4.3",
         "@capacitor/ios": "^7.4.3",
@@ -423,6 +425,24 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-7.1.0.tgz",
+      "integrity": "sha512-W7m09IWrUjZbo7AKeq+rc/KyucxrJekTBg0l4QCm/yDtCejE3hebxp/W2esU26KKCzMc7H3ClkUw32E9lZkwRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/browser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-7.0.2.tgz",
+      "integrity": "sha512-5kySTunCtH+2sezmTjgDfwvspW7GW/hslQECZeLIRM2qefnxjGTc3fmCTeILYK5EuvcxMs+8sF5BhmzzKqOzuQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@capacitor/cli": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
+    "@capacitor/app": "^7.1.0",
+    "@capacitor/browser": "^7.0.2",
     "@capacitor/cli": "^7.4.3",
     "@capacitor/core": "^7.4.3",
     "@capacitor/ios": "^7.4.3",

--- a/server/replitAuth.ts
+++ b/server/replitAuth.ts
@@ -67,6 +67,31 @@ async function upsertUser(
   });
 }
 
+const MAX_RETURN_TO_LENGTH = 2048;
+const ALLOWED_RETURN_TO_SCHEMES = new Set(["golfai"]);
+
+function sanitizeReturnTo(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length > MAX_RETURN_TO_LENGTH) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(value);
+    const scheme = parsed.protocol.replace(":", "");
+    if (ALLOWED_RETURN_TO_SCHEMES.has(scheme)) {
+      return parsed.toString();
+    }
+    return undefined;
+  } catch {
+    if (value.startsWith("/") && !value.startsWith("//")) {
+      return value;
+    }
+    return undefined;
+  }
+}
+
+type SessionWithReturnTo = session.Session & { returnTo?: string };
+
 export async function setupAuth(app: Express) {
   app.set("trust proxy", 1);
   app.use(getSession());
@@ -103,6 +128,14 @@ export async function setupAuth(app: Express) {
   passport.deserializeUser((user: Express.User, cb) => cb(null, user));
 
   app.get("/api/login", (req, res, next) => {
+    const loginSession = req.session as SessionWithReturnTo;
+    const requestedReturnTo = sanitizeReturnTo(req.query.returnTo);
+    if (requestedReturnTo) {
+      loginSession.returnTo = requestedReturnTo;
+    } else if (loginSession.returnTo) {
+      delete loginSession.returnTo;
+    }
+
     passport.authenticate(`replitauth:${req.hostname}`, {
       prompt: "login consent",
       scope: ["openid", "email", "profile", "offline_access"],
@@ -110,8 +143,14 @@ export async function setupAuth(app: Express) {
   });
 
   app.get("/api/callback", (req, res, next) => {
+    const loginSession = req.session as SessionWithReturnTo;
+    const storedReturnTo = sanitizeReturnTo(loginSession.returnTo);
+    if (loginSession.returnTo) {
+      delete loginSession.returnTo;
+    }
+
     passport.authenticate(`replitauth:${req.hostname}`, {
-      successReturnToOrRedirect: "/",
+      successReturnToOrRedirect: storedReturnTo ?? "/",
       failureRedirect: "/api/login",
     })(req, res, next);
   });


### PR DESCRIPTION
## Summary
- persist a validated `returnTo` value in the session during `/api/login` and honor it after the Replit OAuth callback
- add a Capacitor-aware login helper so the landing page launches native auth flows and cleans up listeners when they resolve
- register the `golfai` URL scheme for iOS and add the required Capacitor App/Browser plugins

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5982bf0288328a177d3853f369b3b