### PR TITLE
Fix Info.plist CFBundleURLTypes block

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -55,12 +55,7 @@
                         <key>CFBundleTypeRole</key>
                         <string>Editor</string>
                         <key>CFBundleURLName</key>
-                        <string>golfai</string>
-
-=======
-                        <key>CFBundleURLName</key>
                         <string>com.swingai.golfapp</string>
-
                         <key>CFBundleURLSchemes</key>
                         <array>
                                 <string>golfai</string>


### PR DESCRIPTION
## Summary
- resolve merge artifact in ios/App/App/Info.plist that duplicated the CFBundleURLName entry
- keep the intended CFBundleURLName identifier and ensure a single CFBundleURLName precedes the schemes array

## Testing
- npx cap sync ios

------
https://chatgpt.com/codex/tasks/task_e_68d5c75b21bc832880cbd67d3166f62d